### PR TITLE
Update for Factorio v0.17

### DIFF
--- a/info.json
+++ b/info.json
@@ -1,9 +1,9 @@
 {
   "name": "skan-advanced-solar",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "title": "Skandragon's Advanced Solar",
   "author": "Skandragon",
   "homepage": "https://github.com/skandragon/skan-advanced-solar",
   "description": "Additional solar panels and accumulators to save space.",
-  "factorio_version": "0.16"
+  "factorio_version": "0.17"
 }

--- a/prototypes/entity/advanced-accumulator.lua
+++ b/prototypes/entity/advanced-accumulator.lua
@@ -14,7 +14,7 @@ data:extend({
     {
       type = "electric",
       buffer_capacity = "15MJ",
-      usage_priority = "terciary",
+      usage_priority = "tertiary",
       input_flow_limit = "900kW",
       output_flow_limit = "900kW"
     },

--- a/prototypes/entity/elite-accumulator.lua
+++ b/prototypes/entity/elite-accumulator.lua
@@ -14,7 +14,7 @@ data:extend({
     {
       type = "electric",
       buffer_capacity = "45MJ",
-      usage_priority = "terciary",
+      usage_priority = "tertiary",
       input_flow_limit = "2.7MW",
       output_flow_limit = "2.7MW"
     },

--- a/prototypes/entity/ultimate-accumulator.lua
+++ b/prototypes/entity/ultimate-accumulator.lua
@@ -14,7 +14,7 @@ data:extend({
     {
       type = "electric",
       buffer_capacity = "135MJ",
-      usage_priority = "terciary",
+      usage_priority = "tertiary",
       input_flow_limit = "8.1MW",
       output_flow_limit = "8.1MW"
     },

--- a/prototypes/item/advanced-accumulator.lua
+++ b/prototypes/item/advanced-accumulator.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "advanced-accumulator",
     icon = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator-icon.png",
     icon_size = 32,
-    flags = {"goes-to-quickbar"},
+    flags = {},
     subgroup = "energy",
     order = "e-b",
     place_result = "advanced-accumulator",

--- a/prototypes/item/advanced-solar.lua
+++ b/prototypes/item/advanced-solar.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "advanced-solar",
     icon = "__skan-advanced-solar__/graphics/advanced-solar/advanced-solar-icon.png",
     icon_size = 32,
-    flags = {"goes-to-quickbar"},
+    flags = {},
     subgroup = "energy",
     order = "d[solar-panel]-a[solar-panel]",
     place_result = "advanced-solar",

--- a/prototypes/item/elite-accumulator.lua
+++ b/prototypes/item/elite-accumulator.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "elite-accumulator",
     icon = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator-icon.png",
     icon_size = 32,
-    flags = {"goes-to-quickbar"},
+    flags = {},
     subgroup = "energy",
     order = "e-b",
     place_result = "elite-accumulator",

--- a/prototypes/item/elite-solar.lua
+++ b/prototypes/item/elite-solar.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "elite-solar",
     icon = "__skan-advanced-solar__/graphics/elite-solar/elite-solar-icon.png",
     icon_size = 32,
-    flags = {"goes-to-quickbar"},
+    flags = {},
     subgroup = "energy",
     order = "d[solar-panel]-a[solar-panel]",
     place_result = "elite-solar",

--- a/prototypes/item/ultimate-accumulator.lua
+++ b/prototypes/item/ultimate-accumulator.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "ultimate-accumulator",
     icon = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator-icon.png",
     icon_size = 32,
-    flags = {"goes-to-quickbar"},
+    flags = {},
     subgroup = "energy",
     order = "e-b",
     place_result = "ultimate-accumulator",

--- a/prototypes/item/ultimate-solar.lua
+++ b/prototypes/item/ultimate-solar.lua
@@ -4,7 +4,7 @@ data:extend({
     name = "ultimate-solar",
     icon = "__skan-advanced-solar__/graphics/ultimate-solar/ultimate-solar-icon.png",
     icon_size = 32,
-    flags = {"goes-to-quickbar"},
+    flags = {},
     subgroup = "energy",
     order = "d[solar-panel]-a[solar-panel]",
     place_result = "ultimate-solar",

--- a/prototypes/technology/advanced-accumulator.lua
+++ b/prototypes/technology/advanced-accumulator.lua
@@ -17,8 +17,8 @@ data:extend({
       count = 150,
       ingredients =
       {
-        {"science-pack-1", 1},
-        {"science-pack-2", 1}
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1}
       },
       time = 45
     },

--- a/prototypes/technology/advanced-solar.lua
+++ b/prototypes/technology/advanced-solar.lua
@@ -17,9 +17,9 @@ data:extend({
       count = 100,
       ingredients =
       {
-        {"science-pack-1", 1},
-        {"science-pack-2", 1},
-        {"science-pack-3", 1}
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1},
+        {"chemical-science-pack", 1}
       },
       time = 45
     },

--- a/prototypes/technology/elite-accumulator.lua
+++ b/prototypes/technology/elite-accumulator.lua
@@ -17,9 +17,9 @@ data:extend({
       count = 150,
       ingredients =
       {
-        {"science-pack-1", 1},
-        {"science-pack-2", 1},
-        {"science-pack-3", 1}
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1},
+        {"chemical-science-pack", 1}
       },
       time = 45
     },

--- a/prototypes/technology/elite-solar.lua
+++ b/prototypes/technology/elite-solar.lua
@@ -17,9 +17,9 @@ data:extend({
       count = 200,
       ingredients =
       {
-        {"science-pack-1", 1},
-        {"science-pack-2", 1},
-        {"science-pack-3", 1}
+        {"automation-science-pack", 1},
+        {"logistic-science-pack", 1},
+        {"chemical-science-pack", 1}
       },
       time = 45
     },

--- a/prototypes/technology/ultimate-accumulator.lua
+++ b/prototypes/technology/ultimate-accumulator.lua
@@ -17,10 +17,10 @@ data:extend({
       count = 200,
       ingredients =
       {
-        {"science-pack-1", 2},
-        {"science-pack-2", 2},
-        {"science-pack-3", 1},
-        {"high-tech-science-pack", 1}
+        {"automation-science-pack", 2},
+        {"logistic-science-pack", 2},
+        {"chemical-science-pack", 1},
+        {"utility-science-pack", 1}
       },
       time = 60
     },

--- a/prototypes/technology/ultimate-solar.lua
+++ b/prototypes/technology/ultimate-solar.lua
@@ -17,10 +17,10 @@ data:extend({
       count = 250,
       ingredients =
       {
-        {"science-pack-1", 2},
-        {"science-pack-2", 1},
-        {"science-pack-3", 1},
-        {"high-tech-science-pack", 1}
+        {"automation-science-pack", 2},
+        {"logistic-science-pack", 1},
+        {"chemical-science-pack", 1},
+        {"utility-science-pack", 1}
       },
       time = 60
     },


### PR DESCRIPTION
I've loved using this mod in Factorio 0.16, so I thought I'd try my hand at updating it to work with 0.17.  Happily, this turns out to be really easy; it's just adjusting for a few changes in the modding API: renamed science packs, spelling fixes, and changes due to the new quickbar.

I haven't tried to make the code work for both 0.16 and 0.17, and I'm not sure whether this is feasible, but I can try to investigate this if you feel it's important.

Finally, I based this PR on the tip of master, rather than on your 1.1 release.  I'm not sure if this is the right choice, because 1.2 represents a pretty significant change to the mod that breaks backward compatibility pretty significantly -- any base built to use 1.1 that upgrades to 1.2 is likely to have serious power problems.  A per-map option to allow the user to select between the two behaviors might be a reasonable compromise, but I didn't have the time to investigate this, and in any case I wanted to discuss with you before digging into this at all deeply.