### PR TITLE
Upgrade Planner Support

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -115,7 +115,9 @@ function get_circuit_connector_sprites(mainOffset, shadowOffset, connectorNumber
   end
   return result;
 end
-
+ -- Upgrade Planner Support
+require("prototypes.entity.solar-panel")
+require("prototypes.entity.accumulator")
  -- advanced accumulator
 require("prototypes.entity.advanced-accumulator")
 require("prototypes.item.advanced-accumulator")
@@ -146,3 +148,4 @@ require("prototypes.entity.ultimate-solar")
 require("prototypes.item.ultimate-solar")
 require("prototypes.crafting.ultimate-solar")
 require("prototypes.technology.ultimate-solar")
+

--- a/prototypes/entity/accumulator.lua
+++ b/prototypes/entity/accumulator.lua
@@ -1,9 +1,9 @@
 local vanilla_entity = data.raw["accumulator"]["accumulator"]
 
 if not vanilla_entity.fast_replaceable_group then
-	vanilla_entity.fast_replaceable_group = "accumulator"
+    vanilla_entity.fast_replaceable_group = "accumulator"
 end
 
 if not vanilla_entity.next_upgrade then
-	vanilla_entity.next_upgrade = "advanced-accumulator"
+    vanilla_entity.next_upgrade = "advanced-accumulator"
 end

--- a/prototypes/entity/accumulator.lua
+++ b/prototypes/entity/accumulator.lua
@@ -1,4 +1,4 @@
-local vanilla_entity = data.raw["accumulator"]["accumulator"]
+local vanilla_entity = data.raw["accumulator"]["accumulator"]
 
 if not vanilla_entity.fast_replaceable_group then
 	vanilla_entity.fast_replaceable_group = "accumulator"

--- a/prototypes/entity/accumulator.lua
+++ b/prototypes/entity/accumulator.lua
@@ -1,0 +1,9 @@
+local vanilla_entity = data.raw["accumulator"]["accumulator"]
+
+if not vanilla_entity.fast_replaceable_group then
+	vanilla_entity.fast_replaceable_group = "accumulator"
+end
+
+if not vanilla_entity.next_upgrade then
+	vanilla_entity.next_upgrade = "advanced-accumulator"
+end

--- a/prototypes/entity/advanced-accumulator.lua
+++ b/prototypes/entity/advanced-accumulator.lua
@@ -1,86 +1,82 @@
 data:extend({
-  {
-    type = "accumulator",
-    name = "advanced-accumulator",
-    icon = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator-icon.png",
-    icon_size = 32,
-    flags = {"placeable-neutral", "player-creation"},
-    minable = {hardness = 0.2, mining_time = 0.5, result = "advanced-accumulator"},
-    max_health = 250,
-    corpse = "medium-remnants",
-    collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
-    selection_box = {{-1, -1}, {1, 1}},
-    fast_replaceable_group = "accumulator",
-	  next_upgrade = "elite-accumulator",
-    energy_source =
     {
-      type = "electric",
-      buffer_capacity = "15MJ",
-      usage_priority = "tertiary",
-      input_flow_limit = "900kW",
-      output_flow_limit = "900kW"
-    },
-    picture =
-    {
-      filename = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator.png",
-      priority = "extra-high",
-      width = 124,
-      height = 103,
-      shift = {0.7, -0.2}
-    },
-    charge_animation =
-    {
-      filename = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator-charge-animation.png",
-      width = 138,
-      height = 135,
-      line_length = 8,
-      frame_count = 24,
-      shift = {0.482, -0.638},
-      animation_speed = 0.5
-    },
-    charge_cooldown = 30,
-    charge_light = {intensity = 0.3, size = 7},
-    discharge_animation =
-    {
-      filename = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator-discharge-animation.png",
-      width = 147,
-      height = 128,
-      line_length = 8,
-      frame_count = 24,
-      shift = {0.395, -0.525},
-      animation_speed = 0.5
-    },
-    discharge_cooldown = 60,
-    discharge_light = {intensity = 0.7, size = 7},
-    vehicle_impact_sound =  { filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65 },
-	working_sound =
-    {
-      sound =
-      {
-        filename = "__base__/sound/accumulator-working.ogg",
-        volume = 1
-      },
-      idle_sound = {
-        filename = "__base__/sound/accumulator-idle.ogg",
-        volume = 0.4
-      },
-      max_sounds_per_type = 5
-    },
-	circuit_wire_connection_point =
-    {
-      shadow =
-      {
-        red = {0.984375, 1.10938},
-        green = {0.890625, 1.10938}
-      },
-      wire =
-      {
-        red = {0.6875, 0.59375},
-        green = {0.6875, 0.71875}
-      }
-    },
-    circuit_connector_sprites = get_circuit_connector_sprites({0.46875, 0.5}, {0.46875, 0.8125}, 26),
-    circuit_wire_max_distance = 7.5,
-    default_output_signal = { type = "virtual", name = "signal-A" }
-  }
-})
+        type = "accumulator",
+        name = "advanced-accumulator",
+        icon = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator-icon.png",
+        icon_size = 32,
+        flags = {"placeable-neutral", "player-creation"},
+        minable = {hardness = 0.2, mining_time = 0.5, result = "advanced-accumulator"},
+        max_health = 250,
+        corpse = "medium-remnants",
+        collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
+        selection_box = {{-1, -1}, {1, 1}},
+        fast_replaceable_group = "accumulator",
+        next_upgrade = "elite-accumulator",
+        energy_source =
+        {
+            type = "electric",
+            buffer_capacity = "15MJ",
+            usage_priority = "tertiary",
+            input_flow_limit = "900kW",
+            output_flow_limit = "900kW"
+        },
+        picture =
+        {
+            filename = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator.png",
+            priority = "extra-high",
+            width = 124,
+            height = 103,
+        shift = {0.7, -0.2}},
+        charge_animation =
+        {
+            filename = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator-charge-animation.png",
+            width = 138,
+            height = 135,
+            line_length = 8,
+            frame_count = 24,
+            shift = {0.482, -0.638},
+            animation_speed = 0.5
+        },
+        charge_cooldown = 30,
+        charge_light = {intensity = 0.3, size = 7},
+        discharge_animation =
+        {
+            filename = "__skan-advanced-solar__/graphics/advanced-accumulator/advanced-accumulator-discharge-animation.png",
+            width = 147,
+            height = 128,
+            line_length = 8,
+            frame_count = 24,
+            shift = {0.395, -0.525},
+            animation_speed = 0.5
+        },
+        discharge_cooldown = 60,
+        discharge_light = {intensity = 0.7, size = 7},
+        vehicle_impact_sound = {filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65},
+        working_sound =
+        {
+            sound =
+            {
+                filename = "__base__/sound/accumulator-working.ogg",
+                volume = 1
+            },
+            idle_sound = {
+                filename = "__base__/sound/accumulator-idle.ogg",
+                volume = 0.4
+            },
+            max_sounds_per_type = 5
+        },
+        circuit_wire_connection_point =
+        {
+            shadow =
+            {
+                red = {0.984375, 1.10938},
+            green = {0.890625, 1.10938}},
+            wire =
+            {
+                red = {0.6875, 0.59375},
+            green = {0.6875, 0.71875}}},
+            circuit_connector_sprites = get_circuit_connector_sprites({0.46875, 0.5}, {0.46875, 0.8125}, 26),
+            circuit_wire_max_distance = 7.5,
+        default_output_signal = {type = "virtual", name = "signal-A"}}})
+
+       

--- a/prototypes/entity/advanced-accumulator.lua
+++ b/prototypes/entity/advanced-accumulator.lua
@@ -10,6 +10,8 @@ data:extend({
     corpse = "medium-remnants",
     collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
     selection_box = {{-1, -1}, {1, 1}},
+	fast_replaceable_group = "accumulator",
+	next_upgrade = "elite-accumulator",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/advanced-accumulator.lua
+++ b/prototypes/entity/advanced-accumulator.lua
@@ -10,8 +10,8 @@ data:extend({
     corpse = "medium-remnants",
     collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
     selection_box = {{-1, -1}, {1, 1}},
-	fast_replaceable_group = "accumulator",
-	next_upgrade = "elite-accumulator",
+    fast_replaceable_group = "accumulator",
+	  next_upgrade = "elite-accumulator",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/advanced-solar.lua
+++ b/prototypes/entity/advanced-solar.lua
@@ -10,8 +10,8 @@ data:extend({
     corpse = "big-remnants",
     collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
     selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
-	fast_replaceable_group = "solar-panel",
-	next_upgrade = "elite-solar",
+	  fast_replaceable_group = "solar-panel",
+	  next_upgrade = "elite-solar",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/advanced-solar.lua
+++ b/prototypes/entity/advanced-solar.lua
@@ -1,29 +1,30 @@
 data:extend({
-  {
-    type = "solar-panel",
-    name = "advanced-solar",
-    icon = "__skan-advanced-solar__/graphics/advanced-solar/advanced-solar-icon.png",
-    icon_size = 32,
-    flags = {"placeable-neutral", "player-creation"},
-    minable = {hardness = 0.2, mining_time = 0.5, result = "advanced-solar"},
-    max_health = 200,
-    corpse = "big-remnants",
-    collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
-    selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
-	  fast_replaceable_group = "solar-panel",
-	  next_upgrade = "elite-solar",
-    energy_source =
     {
-      type = "electric",
-      usage_priority = "solar"
-    },
-    picture =
-    {
-      filename = "__skan-advanced-solar__/graphics/advanced-solar/advanced-solar.png",
-      priority = "high",
-      width = 104,
-      height = 96
-    },
-    production = "180kW"
-  }
-})
+        type = "solar-panel",
+        name = "advanced-solar",
+        icon = "__skan-advanced-solar__/graphics/advanced-solar/advanced-solar-icon.png",
+        icon_size = 32,
+        flags = {"placeable-neutral", "player-creation"},
+        minable = {hardness = 0.2, mining_time = 0.5, result = "advanced-solar"},
+        max_health = 200,
+        corpse = "big-remnants",
+        collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
+        selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+        fast_replaceable_group = "solar-panel",
+        next_upgrade = "elite-solar",
+        energy_source =
+        {
+            type = "electric",
+            usage_priority = "solar"
+        },
+        picture =
+        {
+            filename = "__skan-advanced-solar__/graphics/advanced-solar/advanced-solar.png",
+            priority = "high",
+            width = 104,
+            height = 96
+        },
+        production = "180kW"
+    }})
+
+   

--- a/prototypes/entity/advanced-solar.lua
+++ b/prototypes/entity/advanced-solar.lua
@@ -10,6 +10,8 @@ data:extend({
     corpse = "big-remnants",
     collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
     selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+	fast_replaceable_group = "solar-panel",
+	next_upgrade = "elite-solar",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/elite-accumulator.lua
+++ b/prototypes/entity/elite-accumulator.lua
@@ -1,86 +1,82 @@
 data:extend({
-  {
-    type = "accumulator",
-    name = "elite-accumulator",
-    icon = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator-icon.png",
-    icon_size = 32,
-    flags = {"placeable-neutral", "player-creation"},
-    minable = {hardness = 0.2, mining_time = 0.5, result = "elite-accumulator"},
-    max_health = 250,
-    corpse = "medium-remnants",
-    collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
-    selection_box = {{-1, -1}, {1, 1}},
-	  fast_replaceable_group = "accumulator",
-	  next_upgrade = "ultimate-accumulator",
-    energy_source =
     {
-      type = "electric",
-      buffer_capacity = "45MJ",
-      usage_priority = "tertiary",
-      input_flow_limit = "2.7MW",
-      output_flow_limit = "2.7MW"
-    },
-    picture =
-    {
-      filename = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator.png",
-      priority = "extra-high",
-      width = 124,
-      height = 103,
-      shift = {0.7, -0.2}
-    },
-    charge_animation =
-    {
-      filename = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator-charge-animation.png",
-      width = 138,
-      height = 135,
-      line_length = 8,
-      frame_count = 24,
-      shift = {0.482, -0.638},
-      animation_speed = 0.5
-    },
-    charge_cooldown = 30,
-    charge_light = {intensity = 0.3, size = 7},
-    discharge_animation =
-    {
-      filename = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator-discharge-animation.png",
-      width = 147,
-      height = 128,
-      line_length = 8,
-      frame_count = 24,
-      shift = {0.395, -0.525},
-      animation_speed = 0.5
-    },
-    discharge_cooldown = 60,
-    discharge_light = {intensity = 0.7, size = 7},
-	vehicle_impact_sound =  { filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65 },
-    working_sound =
-    {
-      sound =
-      {
-        filename = "__base__/sound/accumulator-working.ogg",
-        volume = 1
-      },
-      idle_sound = {
-        filename = "__base__/sound/accumulator-idle.ogg",
-        volume = 0.4
-      },
-      max_sounds_per_type = 5
-    },
-	circuit_wire_connection_point =
-    {
-      shadow =
-      {
-        red = {0.984375, 1.10938},
-        green = {0.890625, 1.10938}
-      },
-      wire =
-      {
-        red = {0.6875, 0.59375},
-        green = {0.6875, 0.71875}
-      }
-    },
-    circuit_connector_sprites = get_circuit_connector_sprites({0.46875, 0.5}, {0.46875, 0.8125}, 26),
-    circuit_wire_max_distance = 7.5,
-    default_output_signal = { type = "virtual", name = "signal-A" }
-  }
-})
+        type = "accumulator",
+        name = "elite-accumulator",
+        icon = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator-icon.png",
+        icon_size = 32,
+        flags = {"placeable-neutral", "player-creation"},
+        minable = {hardness = 0.2, mining_time = 0.5, result = "elite-accumulator"},
+        max_health = 250,
+        corpse = "medium-remnants",
+        collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
+        selection_box = {{-1, -1}, {1, 1}},
+        fast_replaceable_group = "accumulator",
+        next_upgrade = "ultimate-accumulator",
+        energy_source =
+        {
+            type = "electric",
+            buffer_capacity = "45MJ",
+            usage_priority = "tertiary",
+            input_flow_limit = "2.7MW",
+            output_flow_limit = "2.7MW"
+        },
+        picture =
+        {
+            filename = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator.png",
+            priority = "extra-high",
+            width = 124,
+            height = 103,
+        shift = {0.7, -0.2}},
+        charge_animation =
+        {
+            filename = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator-charge-animation.png",
+            width = 138,
+            height = 135,
+            line_length = 8,
+            frame_count = 24,
+            shift = {0.482, -0.638},
+            animation_speed = 0.5
+        },
+        charge_cooldown = 30,
+        charge_light = {intensity = 0.3, size = 7},
+        discharge_animation =
+        {
+            filename = "__skan-advanced-solar__/graphics/elite-accumulator/elite-accumulator-discharge-animation.png",
+            width = 147,
+            height = 128,
+            line_length = 8,
+            frame_count = 24,
+            shift = {0.395, -0.525},
+            animation_speed = 0.5
+        },
+        discharge_cooldown = 60,
+        discharge_light = {intensity = 0.7, size = 7},
+        vehicle_impact_sound = {filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65},
+        working_sound =
+        {
+            sound =
+            {
+                filename = "__base__/sound/accumulator-working.ogg",
+                volume = 1
+            },
+            idle_sound = {
+                filename = "__base__/sound/accumulator-idle.ogg",
+                volume = 0.4
+            },
+            max_sounds_per_type = 5
+        },
+        circuit_wire_connection_point =
+        {
+            shadow =
+            {
+                red = {0.984375, 1.10938},
+            green = {0.890625, 1.10938}},
+            wire =
+            {
+                red = {0.6875, 0.59375},
+            green = {0.6875, 0.71875}}},
+            circuit_connector_sprites = get_circuit_connector_sprites({0.46875, 0.5}, {0.46875, 0.8125}, 26),
+            circuit_wire_max_distance = 7.5,
+        default_output_signal = {type = "virtual", name = "signal-A"}}})
+
+       

--- a/prototypes/entity/elite-accumulator.lua
+++ b/prototypes/entity/elite-accumulator.lua
@@ -10,6 +10,8 @@ data:extend({
     corpse = "medium-remnants",
     collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
     selection_box = {{-1, -1}, {1, 1}},
+	fast_replaceable_group = "accumulator",
+	next_upgrade = "ultimate-accumulator",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/elite-accumulator.lua
+++ b/prototypes/entity/elite-accumulator.lua
@@ -10,8 +10,8 @@ data:extend({
     corpse = "medium-remnants",
     collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
     selection_box = {{-1, -1}, {1, 1}},
-	fast_replaceable_group = "accumulator",
-	next_upgrade = "ultimate-accumulator",
+	  fast_replaceable_group = "accumulator",
+	  next_upgrade = "ultimate-accumulator",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/elite-solar.lua
+++ b/prototypes/entity/elite-solar.lua
@@ -1,29 +1,30 @@
 data:extend({
-  {
-    type = "solar-panel",
-    name = "elite-solar",
-    icon = "__skan-advanced-solar__/graphics/elite-solar/elite-solar-icon.png",
-    icon_size = 32,
-    flags = {"placeable-neutral", "player-creation"},
-    minable = {hardness = 0.2, mining_time = 0.5, result = "elite-solar"},
-    max_health = 250,
-    corpse = "big-remnants",
-    collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
-    selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
-	  fast_replaceable_group = "solar-panel",
-	  next_upgrade = "ultimate-solar",
-    energy_source =
     {
-      type = "electric",
-      usage_priority = "solar"
-    },
-    picture =
-    {
-      filename = "__skan-advanced-solar__/graphics/elite-solar/elite-solar.png",
-      priority = "high",
-      width = 104,
-      height = 96
-    },
-    production = "540kW"
-  }
-})
+        type = "solar-panel",
+        name = "elite-solar",
+        icon = "__skan-advanced-solar__/graphics/elite-solar/elite-solar-icon.png",
+        icon_size = 32,
+        flags = {"placeable-neutral", "player-creation"},
+        minable = {hardness = 0.2, mining_time = 0.5, result = "elite-solar"},
+        max_health = 250,
+        corpse = "big-remnants",
+        collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
+        selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+        fast_replaceable_group = "solar-panel",
+        next_upgrade = "ultimate-solar",
+        energy_source =
+        {
+            type = "electric",
+            usage_priority = "solar"
+        },
+        picture =
+        {
+            filename = "__skan-advanced-solar__/graphics/elite-solar/elite-solar.png",
+            priority = "high",
+            width = 104,
+            height = 96
+        },
+        production = "540kW"
+    }})
+
+   

--- a/prototypes/entity/elite-solar.lua
+++ b/prototypes/entity/elite-solar.lua
@@ -10,6 +10,8 @@ data:extend({
     corpse = "big-remnants",
     collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
     selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+	fast_replaceable_group = "solar-panel",
+	next_upgrade = "ultimate-solar",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/elite-solar.lua
+++ b/prototypes/entity/elite-solar.lua
@@ -10,8 +10,8 @@ data:extend({
     corpse = "big-remnants",
     collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
     selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
-	fast_replaceable_group = "solar-panel",
-	next_upgrade = "ultimate-solar",
+	  fast_replaceable_group = "solar-panel",
+	  next_upgrade = "ultimate-solar",
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/solar-panel.lua
+++ b/prototypes/entity/solar-panel.lua
@@ -1,0 +1,10 @@
+
+local vanilla_entity = data.raw["solar-panel"]["solar-panel"]
+
+if not vanilla_entity.fast_replaceable_group then
+	vanilla_entity.fast_replaceable_group = "solar-panel"
+end
+
+if not vanilla_entity.next_upgrade then
+	vanilla_entity.next_upgrade = "advanced-solar"
+end

--- a/prototypes/entity/solar-panel.lua
+++ b/prototypes/entity/solar-panel.lua
@@ -1,10 +1,9 @@
-
 local vanilla_entity = data.raw["solar-panel"]["solar-panel"]
 
 if not vanilla_entity.fast_replaceable_group then
-	vanilla_entity.fast_replaceable_group = "solar-panel"
+    vanilla_entity.fast_replaceable_group = "solar-panel"
 end
 
 if not vanilla_entity.next_upgrade then
-	vanilla_entity.next_upgrade = "advanced-solar"
+    vanilla_entity.next_upgrade = "advanced-solar"
 end

--- a/prototypes/entity/ultimate-accumulator.lua
+++ b/prototypes/entity/ultimate-accumulator.lua
@@ -10,6 +10,8 @@ data:extend({
     corpse = "medium-remnants",
     collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
     selection_box = {{-1, -1}, {1, 1}},
+	fast_replaceable_group = "accumulator",
+	next_upgrade = nil,
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/ultimate-accumulator.lua
+++ b/prototypes/entity/ultimate-accumulator.lua
@@ -10,8 +10,8 @@ data:extend({
     corpse = "medium-remnants",
     collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
     selection_box = {{-1, -1}, {1, 1}},
-	fast_replaceable_group = "accumulator",
-	next_upgrade = nil,
+	  fast_replaceable_group = "accumulator",
+	  next_upgrade = nil,
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/ultimate-accumulator.lua
+++ b/prototypes/entity/ultimate-accumulator.lua
@@ -1,86 +1,82 @@
 data:extend({
-  {
-    type = "accumulator",
-    name = "ultimate-accumulator",
-    icon = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator-icon.png",
-    icon_size = 32,
-    flags = {"placeable-neutral", "player-creation"},
-    minable = {hardness = 0.2, mining_time = 0.5, result = "ultimate-accumulator"},
-    max_health = 500,
-    corpse = "medium-remnants",
-    collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
-    selection_box = {{-1, -1}, {1, 1}},
-	  fast_replaceable_group = "accumulator",
-	  next_upgrade = nil,
-    energy_source =
     {
-      type = "electric",
-      buffer_capacity = "135MJ",
-      usage_priority = "tertiary",
-      input_flow_limit = "8.1MW",
-      output_flow_limit = "8.1MW"
-    },
-    picture =
-    {
-      filename = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator.png",
-      priority = "extra-high",
-      width = 124,
-      height = 103,
-      shift = {0.7, -0.2}
-    },
-    charge_animation =
-    {
-      filename = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator-charge-animation.png",
-      width = 138,
-      height = 135,
-      line_length = 8,
-      frame_count = 24,
-      shift = {0.482, -0.638},
-      animation_speed = 0.5
-    },
-    charge_cooldown = 30,
-    charge_light = {intensity = 0.3, size = 7},
-    discharge_animation =
-    {
-      filename = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator-discharge-animation.png",
-      width = 147,
-      height = 128,
-      line_length = 8,
-      frame_count = 24,
-      shift = {0.395, -0.525},
-      animation_speed = 0.5
-    },
-    discharge_cooldown = 60,
-    discharge_light = {intensity = 0.7, size = 7},
-	vehicle_impact_sound =  { filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65 },
-    working_sound =
-    {
-      sound =
-      {
-        filename = "__base__/sound/accumulator-working.ogg",
-        volume = 1
-      },
-      idle_sound = {
-        filename = "__base__/sound/accumulator-idle.ogg",
-        volume = 0.4
-      },
-      max_sounds_per_type = 5
-    },
-	circuit_wire_connection_point =
-    {
-      shadow =
-      {
-        red = {0.984375, 1.10938},
-        green = {0.890625, 1.10938}
-      },
-      wire =
-      {
-        red = {0.6875, 0.59375},
-        green = {0.6875, 0.71875}
-      }
-    },
-    circuit_connector_sprites = get_circuit_connector_sprites({0.46875, 0.5}, {0.46875, 0.8125}, 26),
-    circuit_wire_max_distance = 7.5,
-    default_output_signal = { type = "virtual", name = "signal-A" }
-  }
-})
+        type = "accumulator",
+        name = "ultimate-accumulator",
+        icon = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator-icon.png",
+        icon_size = 32,
+        flags = {"placeable-neutral", "player-creation"},
+        minable = {hardness = 0.2, mining_time = 0.5, result = "ultimate-accumulator"},
+        max_health = 500,
+        corpse = "medium-remnants",
+        collision_box = {{-0.9, -0.9}, {0.9, 0.9}},
+        selection_box = {{-1, -1}, {1, 1}},
+        fast_replaceable_group = "accumulator",
+        next_upgrade = nil,
+        energy_source =
+        {
+            type = "electric",
+            buffer_capacity = "135MJ",
+            usage_priority = "tertiary",
+            input_flow_limit = "8.1MW",
+            output_flow_limit = "8.1MW"
+        },
+        picture =
+        {
+            filename = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator.png",
+            priority = "extra-high",
+            width = 124,
+            height = 103,
+        shift = {0.7, -0.2}},
+        charge_animation =
+        {
+            filename = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator-charge-animation.png",
+            width = 138,
+            height = 135,
+            line_length = 8,
+            frame_count = 24,
+            shift = {0.482, -0.638},
+            animation_speed = 0.5
+        },
+        charge_cooldown = 30,
+        charge_light = {intensity = 0.3, size = 7},
+        discharge_animation =
+        {
+            filename = "__skan-advanced-solar__/graphics/ultimate-accumulator/ultimate-accumulator-discharge-animation.png",
+            width = 147,
+            height = 128,
+            line_length = 8,
+            frame_count = 24,
+            shift = {0.395, -0.525},
+            animation_speed = 0.5
+        },
+        discharge_cooldown = 60,
+        discharge_light = {intensity = 0.7, size = 7},
+        vehicle_impact_sound = {filename = "__base__/sound/car-metal-impact.ogg", volume = 0.65},
+        working_sound =
+        {
+            sound =
+            {
+                filename = "__base__/sound/accumulator-working.ogg",
+                volume = 1
+            },
+            idle_sound = {
+                filename = "__base__/sound/accumulator-idle.ogg",
+                volume = 0.4
+            },
+            max_sounds_per_type = 5
+        },
+        circuit_wire_connection_point =
+        {
+            shadow =
+            {
+                red = {0.984375, 1.10938},
+            green = {0.890625, 1.10938}},
+            wire =
+            {
+                red = {0.6875, 0.59375},
+            green = {0.6875, 0.71875}}},
+            circuit_connector_sprites = get_circuit_connector_sprites({0.46875, 0.5}, {0.46875, 0.8125}, 26),
+            circuit_wire_max_distance = 7.5,
+        default_output_signal = {type = "virtual", name = "signal-A"}}})
+
+       

--- a/prototypes/entity/ultimate-solar.lua
+++ b/prototypes/entity/ultimate-solar.lua
@@ -9,7 +9,9 @@ data:extend({
     max_health = 500,
     corpse = "big-remnants",
     collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
-    selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+    selection_box = {{-1.5, -1.5}, {1.5, 1.5}},	
+	fast_replaceable_group = "solar-panel",
+	next_upgrade = nil,
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/ultimate-solar.lua
+++ b/prototypes/entity/ultimate-solar.lua
@@ -10,8 +10,8 @@ data:extend({
     corpse = "big-remnants",
     collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
     selection_box = {{-1.5, -1.5}, {1.5, 1.5}},	
-	fast_replaceable_group = "solar-panel",
-	next_upgrade = nil,
+	  fast_replaceable_group = "solar-panel",
+	  next_upgrade = nil,
     energy_source =
     {
       type = "electric",

--- a/prototypes/entity/ultimate-solar.lua
+++ b/prototypes/entity/ultimate-solar.lua
@@ -1,29 +1,30 @@
 data:extend({
-  {
-    type = "solar-panel",
-    name = "ultimate-solar",
-    icon = "__skan-advanced-solar__/graphics/ultimate-solar/ultimate-solar-icon.png",
-    icon_size = 32,
-    flags = {"placeable-neutral", "player-creation"},
-    minable = {hardness = 0.2, mining_time = 0.5, result = "ultimate-solar"},
-    max_health = 500,
-    corpse = "big-remnants",
-    collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
-    selection_box = {{-1.5, -1.5}, {1.5, 1.5}},	
-	  fast_replaceable_group = "solar-panel",
-	  next_upgrade = nil,
-    energy_source =
     {
-      type = "electric",
-      usage_priority = "solar"
-    },
-    picture =
-    {
-      filename = "__skan-advanced-solar__/graphics/ultimate-solar/ultimate-solar.png",
-      priority = "high",
-      width = 104,
-      height = 96
-    },
-    production = "1.62MW"
-  }
-})
+        type = "solar-panel",
+        name = "ultimate-solar",
+        icon = "__skan-advanced-solar__/graphics/ultimate-solar/ultimate-solar-icon.png",
+        icon_size = 32,
+        flags = {"placeable-neutral", "player-creation"},
+        minable = {hardness = 0.2, mining_time = 0.5, result = "ultimate-solar"},
+        max_health = 500,
+        corpse = "big-remnants",
+        collision_box = {{-1.4, -1.4}, {1.4, 1.4}},
+        selection_box = {{-1.5, -1.5}, {1.5, 1.5}},
+        fast_replaceable_group = "solar-panel",
+        next_upgrade = nil,
+        energy_source =
+        {
+            type = "electric",
+            usage_priority = "solar"
+        },
+        picture =
+        {
+            filename = "__skan-advanced-solar__/graphics/ultimate-solar/ultimate-solar.png",
+            priority = "high",
+            width = 104,
+            height = 96
+        },
+        production = "1.62MW"
+    }})
+
+   


### PR DESCRIPTION
#Upgrade Planner Support

Hello, 

This is one of my favorite factorio mods and one of the things I've been desperately wishing it had was upgrade planner support. I've implemented it and cleaned up code formatting (just using a linter) in the files I touched. 

The code is pretty simple. I've added next_upgrade and fast_replaceable_group to each of the accumulators and solar panels. In addition, I've added support for the vanilla entities so they can be upgraded from.

